### PR TITLE
Update Inputs and Packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cache-nix-action": {
       "flake": false,
       "locked": {
-        "lastModified": 1742117978,
-        "narHash": "sha256-L4g4bE4/7yaWsMp9GPXS2us/JIFk31Etb4RK8QjO8sY=",
+        "lastModified": 1745238870,
+        "narHash": "sha256-m28CuQnXhhE51+Ad2K9iAbbYwLCumqrpTB8I5pBtahc=",
         "owner": "nix-community",
         "repo": "cache-nix-action",
-        "rev": "3ec01582d2f258e5cde7fe2921cd8c49884104f5",
+        "rev": "135667ec418502fa5a3598af6fb9eb733888ce6a",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743964447,
-        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "lastModified": 1745526057,
+        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
         "type": "github"
       },
       "original": {

--- a/packages/nrf-regtool/default.nix
+++ b/packages/nrf-regtool/default.nix
@@ -7,13 +7,13 @@
 
 python.pkgs.buildPythonApplication rec {
   pname = "nrf-regtool";
-  version = "9.0.1";
+  version = "9.1.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "nrf_regtool";
     inherit version;
-    hash = "sha256-DEs+GCUbgXBnOVBqZPhXARJZvdbTlv9Wxc1c43meZM4=";
+    hash = "sha256-in1lmhzNBtty7tmvc1GyoJei0OkR3u7EvdiunY6VS2I=";
   };
 
   build-system = [


### PR DESCRIPTION
Updates flake inputs and bumps `nrf-regtool` to `9.1.0`.