### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cache-nix-action": {
       "flake": false,
       "locked": {
-        "lastModified": 1745238870,
-        "narHash": "sha256-m28CuQnXhhE51+Ad2K9iAbbYwLCumqrpTB8I5pBtahc=",
+        "lastModified": 1746350578,
+        "narHash": "sha256-66auSJUldF+QLnMZEvOR9y9+P6doadeHmYl5UDFqVic=",
         "owner": "nix-community",
         "repo": "cache-nix-action",
-        "rev": "135667ec418502fa5a3598af6fb9eb733888ce6a",
+        "rev": "76f6697d63b7378f7161d52f3d81784130ecd90d",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745526057,
-        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates pinned versions of `nixpkgs` and `cache-nix-action`.