### PR TITLE
Add missing metadata to packages

### DIFF
--- a/packages/doxmlparser/default.nix
+++ b/packages/doxmlparser/default.nix
@@ -17,4 +17,11 @@ buildPythonPackage rec {
   };
 
   format = "wheel";
+
+  meta = {
+    description = "This is a python package to make it easier to parse the XML output produced by doxygen.";
+    homepage = "https://pypi.org/project/doxmlparser/";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ ];
+  };
 }

--- a/packages/pydebuggerconfig/default.nix
+++ b/packages/pydebuggerconfig/default.nix
@@ -21,4 +21,12 @@ buildPythonPackage rec {
   format = "wheel";
 
   propagatedBuildInputs = [ pyedbglib ];
+
+  meta = {
+    description = "pydebuggerconfig is a utility for accessing the configuration information stored inside the PKOB nano on-board debugger, typically found on Curiosity Nano kits.";
+    homepage = "https://pypi.org/project/pydebuggerconfig/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "pydebuggerconfig";
+  };
 }

--- a/packages/pyedbglib/default.nix
+++ b/packages/pyedbglib/default.nix
@@ -21,4 +21,11 @@ buildPythonPackage rec {
   format = "wheel";
 
   propagatedBuildInputs = [ pyserial ];
+
+  meta = {
+    description = "pyedbglib is a low-level protocol library for communicating with Microchip CMSIS-DAP based debuggers";
+    homepage = "https://pypi.org/project/pyedbglib/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
 }

--- a/packages/pykitinfo/default.nix
+++ b/packages/pykitinfo/default.nix
@@ -31,4 +31,12 @@ buildPythonPackage rec {
     pyedbglib
     pydebuggerconfig
   ];
+
+  meta = {
+    description = "pykitinfo provides information about connected Microchip development kits and tools";
+    homepage = "https://pypi.org/project/pykitinfo/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "pykitinfo";
+  };
 }

--- a/packages/pymcuprog/default.nix
+++ b/packages/pymcuprog/default.nix
@@ -21,4 +21,12 @@ buildPythonPackage rec {
   format = "wheel";
 
   propagatedBuildInputs = [ pyedbglib ];
+
+  meta = {
+    description = "pymcuprog is a utility for programming various Microchip MCU devices using Microchip CMSIS-DAP based debuggers";
+    homepage = "https://pypi.org/project/pymcuprog/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "pymcuprog";
+  };
 }


### PR DESCRIPTION
Adds previously missing metadata such as description and license info to:
- doxmlparser
- pydebuggerconfig
- pyedbglib
- pykitinfo
- pymcuprog