### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750506804,
-        "narHash": "sha256-VLFNc4egNjovYVxDGyBYTrvVCgDYgENp5bVi9fPTDYc=",
+        "lastModified": 1756787288,
+        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4206c4cb56751df534751b058295ea61357bbbaa",
+        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
 
           inherit (pkgs.python3Packages)
             hdf5storage
+            lxml5
             pydebuggerconfig
             pyedbglib
             pykitinfo

--- a/overlay.nix
+++ b/overlay.nix
@@ -4,6 +4,7 @@ let
   deptry = python.callPackage ./packages/deptry { };
   hdf5storage = python.callPackage ./packages/hdf5storage { inherit deptry; };
   nrf-regtool = python.callPackage ./packages/nrf-regtool { inherit svada; };
+  lxml5 = python.callPackage ./packages/lxml5 { };
   pydebuggerconfig = python.callPackage ./packages/pydebuggerconfig { inherit pyedbglib; };
   pyedbglib = python.callPackage ./packages/pyedbglib { };
   pykitinfo = python.callPackage ./packages/pykitinfo { inherit pydebuggerconfig pyedbglib; };
@@ -29,6 +30,7 @@ in
     (pyfinal: pyprev: {
       inherit
         hdf5storage
+        lxml5
         pydebuggerconfig
         pyedbglib
         pykitinfo

--- a/overlay.nix
+++ b/overlay.nix
@@ -14,7 +14,7 @@ let
   sphinx-csv-filter = python.callPackage ./packages/sphinx-csv-filter { };
   sphinx-lint = python.callPackage ./packages/sphinx-lint { };
   sphobjinv = python.callPackage ./packages/sphobjinv { };
-  svada = python.callPackage ./packages/svada { };
+  svada = python.callPackage ./packages/svada { inherit lxml5; };
 in
 {
   # Top-level packages

--- a/packages/lxml5/default.nix
+++ b/packages/lxml5/default.nix
@@ -55,6 +55,11 @@ buildPythonPackage rec {
     ];
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-quiet 'Cython>=3.0.11, < 3.1.0' 'Cython>=3.0.11'
+  '';
+
   pythonImportsCheck = [
     "lxml"
     "lxml.etree"

--- a/packages/lxml5/default.nix
+++ b/packages/lxml5/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  cython,
+  setuptools,
+  wheel,
+  cssselect,
+  libxml2,
+  libxslt,
+  lxml-html-clean,
+  html5lib,
+  beautifulsoup4,
+  zlib,
+}:
+
+buildPythonPackage rec {
+  pname = "lxml5";
+  version = "5.3.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "lxml";
+    inherit version;
+    hash = "sha256-dzlH0O2AndrYJLexRGfhpIG4l26HJ4rEpzDC98f83cE=";
+  };
+
+  nativeBuildInputs = [
+    libxml2.dev
+    libxslt.dev
+  ];
+
+  build-system = [
+    cython
+    setuptools
+    wheel
+  ];
+
+  buildInputs = [
+    zlib
+  ];
+
+  optional-dependencies = {
+    cssselect = [
+      cssselect
+    ];
+    html-clean = [
+      lxml-html-clean
+    ];
+    html5 = [
+      html5lib
+    ];
+    htmlsoup = [
+      beautifulsoup4
+    ];
+  };
+
+  pythonImportsCheck = [
+    "lxml"
+    "lxml.etree"
+  ];
+
+  meta = {
+    description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API";
+    homepage = "https://pypi.org/project/lxml/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/packages/svada/default.nix
+++ b/packages/svada/default.nix
@@ -2,6 +2,7 @@
   lib,
   python,
   fetchPypi,
+  lxml5,
 }:
 
 python.pkgs.buildPythonApplication rec {
@@ -26,7 +27,7 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   dependencies = with python.pkgs; [
-    lxml
+    lxml5
     numpy_2
     typing-extensions
   ];


### PR DESCRIPTION
Updates nixpkgs input. This unfortunately pulls in a version of lxml that is incompatible with svada. To resolve this, init our own lxml5 package and use that. That package itself depends on Cython < 3.10, but relaxing that dependency doesn't seem to cause any issues.